### PR TITLE
Style landing page with Radix Themes components

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,7 +18,9 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body>
-        <Theme>{children}</Theme>
+        <Theme accentColor="indigo" grayColor="slate" radius="large" scaling="105%" appearance="dark">
+          {children}
+        </Theme>
       </body>
     </html>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,112 @@
 import Hello from '@/components/Hello';
-import { Badge, Flex, Link } from '@radix-ui/themes';
+import {
+  Badge,
+  Box,
+  Button,
+  Card,
+  Flex,
+  Heading,
+  Link,
+  Separator,
+  Text,
+} from '@radix-ui/themes';
+import NextLink from 'next/link';
 
 export default function Home() {
   const env = process.env.NEXT_PUBLIC_ENV ?? 'preview';
+  const features = [
+    {
+      title: 'Radix Themes',
+      description: 'Preconfigured design system with accessible building blocks and consistent styling.',
+    },
+    {
+      title: 'CI-ready',
+      description: 'Linting and type-check scripts wired for Vercel deployments out of the box.',
+    },
+    {
+      title: 'API health route',
+      description: 'Monitor deployments quickly with a built-in health check endpoint.',
+    },
+  ];
+
   return (
-    <Flex direction="column" minHeight="100vh" align="center" justify="center" gap="4" p="6">
-      <Hello />
-      <Link href="/api/health">API Health</Link>
-      <Badge>ENV: {env}</Badge>
-    </Flex>
+    <Box
+      asChild
+      style={{
+        minHeight: '100vh',
+        background:
+          'radial-gradient(circle at 0% 0%, rgba(129, 140, 248, 0.2), transparent 55%), radial-gradient(circle at 80% 0%, rgba(45, 212, 191, 0.18), transparent 60%), #09090b',
+      }}
+    >
+      <main>
+        <Flex
+          direction="column"
+          align="center"
+          gap="6"
+          style={{ maxWidth: '960px', margin: '0 auto', padding: '96px 24px', textAlign: 'center' }}
+        >
+          <Badge color="jade" variant="surface">
+            Now shipping with Radix Themes
+          </Badge>
+          <Hello />
+          <Text size="4" color="gray">
+            Opinionated Next.js starter wired for Vercel — lean tooling, health checks, and a modern UI kit.
+          </Text>
+
+          <Flex gap="4" wrap="wrap" justify="center">
+            <Button size="3" asChild>
+              <NextLink href="/api/health">Check API Health</NextLink>
+            </Button>
+            <Button size="3" variant="soft" asChild>
+              <Link href="https://nextjs.org/docs" target="_blank" rel="noreferrer">
+                Next.js Docs
+              </Link>
+            </Button>
+          </Flex>
+
+          <Card
+            variant="surface"
+            size="4"
+            style={{
+              width: '100%',
+              maxWidth: '520px',
+              background:
+                'linear-gradient(135deg, rgba(14, 165, 233, 0.18), transparent 60%), rgba(15, 23, 42, 0.85)',
+            }}
+          >
+            <Flex direction="column" gap="3" align="center">
+              <Badge color="blue" variant="soft">
+                Active Environment
+              </Badge>
+              <Heading size="6" weight="bold">
+                {env.toUpperCase()}
+              </Heading>
+              <Text size="2" color="gray">
+                Tailor your deployment previews with <code>NEXT_PUBLIC_ENV</code>.
+              </Text>
+              <Separator orientation="horizontal" size="4" my="1" />
+              <Text size="2" color="gray">
+                Deploy to Vercel and your environment will surface right here.
+              </Text>
+            </Flex>
+          </Card>
+
+          <Flex gap="4" wrap="wrap" justify="center">
+            {features.map((feature) => (
+              <Card key={feature.title} size="3" variant="classic" style={{ width: '260px' }}>
+                <Flex direction="column" gap="2" align="start">
+                  <Heading as="h3" size="4">
+                    {feature.title}
+                  </Heading>
+                  <Text size="2" color="gray" align="left">
+                    {feature.description}
+                  </Text>
+                </Flex>
+              </Card>
+            ))}
+          </Flex>
+        </Flex>
+      </main>
+    </Box>
   );
 }

--- a/src/components/Hello.tsx
+++ b/src/components/Hello.tsx
@@ -1,5 +1,12 @@
-import { Heading } from '@radix-ui/themes';
+import { Heading, Text } from '@radix-ui/themes';
 
 export default function Hello() {
-  return <Heading size="8">Hello from Next.js!</Heading>;
+  return (
+    <Heading size="9" weight="bold" align="center">
+      Launch faster with{' '}
+      <Text as="span" color="indigo">
+        Vibe
+      </Text>
+    </Heading>
+  );
 }


### PR DESCRIPTION
## Summary
- configure the global Radix Theme provider with custom accent, gray palette, radius, scaling, and dark appearance
- redesign the home page with Radix Themes components including hero copy, calls to action, environment status, and feature highlights
- refresh the Hello heading component to better showcase the template branding

## Testing
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68d8e77ad9c883289c01a4ea77402963